### PR TITLE
adds orNull to a contract, allowing a specific contract to specify that ...

### DIFF
--- a/contract.face.js
+++ b/contract.face.js
@@ -62,7 +62,7 @@ contractObject.closeCycle
     .doc("See: `optional`"),
 
   orNull: c.method(contractObject).returns(contractObject)
-    .doc("Relaxes the definition of 'missing' for this contract - allows the checked data to be null or a non-null value matching this contract."),
+    .doc("Returns a contract with a relaxed definition of 'missing' - allows the checked data to be null or a non-null value matching this contract."),
   
   doc: c.method(contractObject).extraArgs([c.string]).returns(contractObject)
     .doc("Returns `this` with zero or more strings set as the `theDoc` array.",

--- a/contract.face.js
+++ b/contract.face.js
@@ -60,6 +60,9 @@ contractObject.closeCycle
   
   optional: c.method(contractObject).returns(contractObject)
     .doc("See: `optional`"),
+
+  orNull: c.method(contractObject).returns(contractObject)
+    .doc("Relaxes the definition of 'missing' for this contract - allows the checked data to be null or a non-null value matching this contract."),
   
   doc: c.method(contractObject).extraArgs([c.string]).returns(contractObject)
     .doc("Returns `this` with zero or more strings set as the `theDoc` array.",

--- a/contract.impl.js
+++ b/contract.impl.js
@@ -407,7 +407,6 @@ Contract.prototype = {
 
   orNull: function () {
     var nonNullCheck = this.check;
-    var nonNullToString = this.toString;
     return gentleUpdate (or (value (null), this), { 
       isMissing: function (v) { return ! __.isUndefined(v) }
     });

--- a/contract.impl.js
+++ b/contract.impl.js
@@ -406,7 +406,6 @@ Contract.prototype = {
   },
 
   orNull: function () {
-    var nonNullCheck = this.check;
     return gentleUpdate (or (value (null), this), { 
       isMissing: function (v) { return ! __.isUndefined(v) }
     });

--- a/contract.spec.js
+++ b/contract.spec.js
@@ -90,6 +90,21 @@ describe ("nothing", function () {
   it ("report check name", function () { (function () { c.nothing.wrap(5, 'test'); }).should.throwContract(/test/); });
 });
 
+describe ("orNull", function () {
+  it ("rejects undefined", function () {
+    (function () { c.string.orNull().check (undefined) ; }).should.throwContract();
+  });
+  it ("allows null", function () {
+    (function () { c.string.orNull().check (null); }).should.not.throw();
+  });
+  it ("lets original contract pass if non-null", function () {
+    (function () { c.string.orNull().check ("hello"); }).should.not.throw();
+  });
+  it ("lets original contract fail if non-null", function () {
+    (function () { c.string.orNull().check (5); }).should.throwContract();
+  });
+});
+
 describe ("value", function () {
   it ("pass same", function () { c.value(5).check(5).should.eql(5); });
   it ("reject different", function () { (function () { c.value(5).check(6); }).should.throwContract(); });

--- a/contract.spec.js
+++ b/contract.spec.js
@@ -190,6 +190,7 @@ describe ("object", function () {
   it ("fails nested", function () { (function () { c.object({x: c.object({y: c.value(5)})}).check({x: { y: 10}}); }).should.throwContract(); });
   it ("fails missing field", function () { (function () { c.object({x: c.value(5), y:c.value(10)}).check({ x: 5, z: 10}); }).should.throwContract(); });
   it ("fails missing field, nested", function () { (function () { c.object({x: c.object({y: c.value(5)})}).check({x: { z: 10}}); }).should.throwContract(); });
+  it ("fails null field", function () { (function () { c.object({x: c.value(5), y:c.value(10)}).check({ x: 5, y: null}); }).should.throwContract(); });
 
   it ("optional field missing", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5}).should.ok; });
   it ("optional field, passing", function () { c.object({x: c.value(5), y:c.optional(c.value(10))}).check({x: 5, y:10}).should.ok; });


### PR DESCRIPTION
...one of its accepted values is null, instead of hard-coding this definition of a missing value.

I took a stab at this.  What do we think of this approach?  i.e. let the contract define isMissing, and orNull lets you specify that a particular contract also allows null.

@gmarceau @jonahkagan